### PR TITLE
simple HTTP proxy support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 # - *$allow_insecure: Default value false
 # - *$username: set basic auth username
 # - *$password: set basic auth password
+# - *$proxy: HTTP proxy in the form of "hostname:port"; e.g. "myproxy:8080"
 #
 # Example usage:
 #
@@ -47,7 +48,8 @@ define archive (
   $src_target     = '/usr/src',
   $allow_insecure = false,
   $username = undef,
-  $password = undef ){
+  $password = undef,
+  $proxy          = undef ){
 
   archive::download {"${name}.${extension}":
     ensure         => $ensure,
@@ -60,7 +62,8 @@ define archive (
     src_target     => $src_target,
     allow_insecure => $allow_insecure,
     username       => $username,
-    password       => $password
+    password       => $password,
+    proxy          => $proxy
   }
 
   archive::extract { $name:


### PR DESCRIPTION
Our production machines can only make HTTP connections through a proxy server, so I added a parameter to the main and download classes that can be used to set curl's `--proxy` argument.
