### PR TITLE
include is required.....

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -89,7 +89,6 @@ define archive::download (
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               notify  => Exec["download archive ${name} and check sum"],
-              require => Package['curl'],
             }
 
           }
@@ -146,7 +145,6 @@ define archive::download (
         creates     => "${src_target}/${name}",
         logoutput   => true,
         timeout     => $timeout,
-        require     => Package['curl'],
         notify      => $notify,
         refreshonly => $refreshonly,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,14 @@ define archive (
   $dependency_class = 'archive::prerequisites',
   $exec_path        = ['/usr/local/bin', '/usr/bin', '/bin']) {
 
-  include $dependency_class
+  if $dependency_class != '' {
+    include $dependency_class
+    $dep_class = Class[$dependency_class]
+  }
+  else 
+  {
+    $dep_class = undef
+  }
 
   archive::download {"${name}.${extension}":
     ensure         => $ensure,
@@ -72,7 +79,7 @@ define archive (
     username       => $username,
     password       => $password,
     proxy          => $proxy,
-    require        => Class[$dependency_class],
+    require        => $dep_class,
     exec_path      => $exec_path,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,8 +54,10 @@ define archive (
   $username         = undef,
   $password         = undef,
   $proxy            = undef,
-  $dependency_class = Class['archive::prerequisites'],
+  $dependency_class = 'archive::prerequisites',
   $exec_path        = ['/usr/local/bin', '/usr/bin', '/bin']) {
+
+  include $dependency_class
 
   archive::download {"${name}.${extension}":
     ensure         => $ensure,
@@ -70,7 +72,7 @@ define archive (
     username       => $username,
     password       => $password,
     proxy          => $proxy,
-    require        => $dependency_class,
+    require        => Class[$dependency_class],
     exec_path      => $exec_path,
   }
 

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -12,7 +12,9 @@ class archive::prerequisites {
   $packages = [ 'curl', 'unzip', 'tar', ]
 
   # install additional packages if missing
+  anchor { 'archive::prerequisites::begin': } ->
   package { $packages:
     ensure => installed,
-  }
+  } -> 
+  anchor { 'archive::prerequisites::end': }
 }


### PR DESCRIPTION
The require metaparameter does not automatically include the specified resource so the include is still needed.

Without the include we get the following error.

```
'Invalid relationship: Archive::Download[<somefile>] { require => Class[Archive::Prerequisites] }, because Class[Archive::Prerequisites] doesn't seem to be in the catalog'
```
