### PR TITLE
use !defined to conditionally install prereqs

### DIFF
--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -7,12 +7,15 @@
 # None
 #
 class archive::prerequisites {
+  if !defined(Package['curl']) {
+    package{'curl': ensure => present }
+  }
 
-  # list of packages needed for download and extraction
-  $packages = [ 'curl', 'unzip', 'tar', ]
+  if !defined(Package['tar']) {
+    package{'tar': ensure => present }
+  }
 
-  # install additional packages if missing
-  package { $packages:
-    ensure => installed,
+  if !defined(Package['unzip']) {
+    package{'unzip': ensure => present }
   }
 }


### PR DESCRIPTION
#27

on further research:

this was a known potential issue and was fixed here: https://github.com/gini/puppet-archive/commit/610e943d0c8b60c01788335b74920b11b95fe201

but it was later changed to this "flexible" version: https://github.com/gini/puppet-archive/commit/0f133ab5629a6adf2030e943371321ba642fe634

using `$dependency_class` is novel, but `archive` is a defined type, not a class: I can't override that value with automatic hiera binding.

I'm running this branch in my lab environment right now and it seems to solve my issues with `gini/archive` and `bfraser/grafana`.
