### PR TITLE
use ensure_packages function for prereqs

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,5 @@ project_page 'https://github.com/gini/puppet-archive'
 source       'https://github.com/gini/puppet-archive'
 summary      'Puppet module to download and extract tar and zip archives'
 description  'This module downloads archives (tar.{gz,bz2,xz} and zip) using curl and extracts them to a given directory.'
+
+dependency 'puppetlabs/stdlib', '>= 2.6.0'

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -12,7 +12,5 @@ class archive::prerequisites {
   $packages = [ 'curl', 'unzip', 'tar', ]
 
   # install additional packages if missing
-  package { $packages:
-    ensure => installed,
-  }
+  ensure_packages($packages)
 }


### PR DESCRIPTION
This should fix duplicate declarations, especially since these packages are pretty 'low level' and likely to be included in other modules.
