### PR TITLE
Disabled checksum always fails

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -131,7 +131,11 @@ define archive::download (
         }
       }
     }
-    false :  { notice('No checksum for this archive') }
+    false :  {
+      notice('No checksum for this archive')
+      # Don't run rm-on-error - return code 0
+      $checksum_cmd = 'test 0'
+    }
     default: { fail("Unknown checksum value: '${checksum}'") }
   }
 


### PR DESCRIPTION
When disabling checksum, the code does not work because it runs rm-on-error-${name} anyway
