### PR TITLE
return a non-zero exit code on download error

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -91,7 +91,7 @@ define archive::download (
             }
 
             exec {"download digest of archive ${name}":
-              command => "curl ${basic_auth} ${insecure_arg} ${redirects_arg} ${proxy_arg} -s -o ${src_target}/${name}.${digest_type} ${digest_src}",
+              command => "curl -f ${basic_auth} ${insecure_arg} ${redirects_arg} ${proxy_arg} -s -o ${src_target}/${name}.${digest_type} ${digest_src}",
               path    => $exec_path,
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
@@ -152,7 +152,7 @@ define archive::download (
       }
 
       exec {"download archive ${name} and check sum":
-        command     => "curl ${basic_auth} -s ${insecure_arg} ${redirects_arg} ${proxy_arg} -o ${src_target}/${name} ${url}",
+        command     => "curl -f ${basic_auth} -s ${insecure_arg} ${redirects_arg} ${proxy_arg} -o ${src_target}/${name} ${url}",
         path        => $exec_path,
         creates     => "${src_target}/${name}",
         logoutput   => true,


### PR DESCRIPTION
Ask curl to return a non-zero exit code (22) and not produce output, when a web server returns a failure code (HTTP status other than 200).  Prior to this change, if the web server returned an error and content (like details of the REST error in the body), curl would still write to the archive file, and puppet would merrily chug along.  The only thing that would eventually stop this was having checksums enabled... but not all repos provide the checksum files.
